### PR TITLE
MySQL can handle 4-byte UTF-8 today with the proper encoding

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -55,21 +55,9 @@ module HTML
       # Strip all HTML tags from the document.
       FULL = { :elements => [] }
 
-      # Match unicode chars encoded on 4 bytes in UTF-8
-      MB4_REGEXP = /[^\u{9}-\u{ffff}]/
-
-      # Remove utf-8 characters encoded on 4 bytes,
-      # because MySQL doesn't handle them.
-      def encode_mb4(doc)
-        doc.search("text()").each do |node|
-          node.content = node.content.gsub(MB4_REGEXP) { |c| "&##{c.unpack('U')[0]};" }
-        end
-        doc
-      end
-
       # Sanitize markup using the Sanitize library.
       def call
-        encode_mb4 Sanitize.node!(doc, whitelist)
+        Sanitize.node!(doc, whitelist)
       end
 
       # The whitelist to use when sanitizing. This can be passed in the context


### PR DESCRIPTION
The problem with escaping some characters in this function is that it adds "&" characters which are going to be escaped another time later on.

This is the main reason why content on Linuxfr cannot use 4-byte UTF-8: "🐧" shows as "&amp;#128039;" because is gets "sanitised" into `&#128039;` which is then turned into `&amp;#128039;`

If migrating the database to utf8mb4 doesn't end up well, it might make sense to keep this `encode_mb4` part and investigate further to prevent the "&" from being escaped a second time, but if the migration to utf8mb4 goes well, storing characters as regular UTF-8 instead of escaping them is the best and easiest solution.

This is related to linuxfrorg/linuxfr.org#206