### PR TITLE
Allow slashes in [[Wikipedia]] links

### DIFF
--- a/lib/html/pipeline/custom_links_filter.rb
+++ b/lib/html/pipeline/custom_links_filter.rb
@@ -7,7 +7,7 @@ module HTML
     class CustomLinksFilter < Filter
 
       LF_REGEXP = /\[\[\[([ '\.:\-\p{Word}]+)\]\]\]/
-      WP_REGEXP = /\[\[([ '\.+:!\-\(\)\p{Word}]+)\]\]/
+      WP_REGEXP = /\[\[([ '\.+:!\-\/\(\)\p{Word}]+)\]\]/
 
       LF_TITLE = "Lien du wiki interne LinuxFr.org"
       WP_TITLE = "Définition Wikipédia"


### PR DESCRIPTION
Fixes the following bug report: http://linuxfr.org/suivi/liens-vers-wikipedia-casses-quand-ils-contiennent-un

Wikipedia pages can contain slashes, like the example used in the above report: [[S/MIME]].