### PR TITLE
Allow tel schema

### DIFF
--- a/lib/html/pipeline/linuxfr.rb
+++ b/lib/html/pipeline/linuxfr.rb
@@ -25,7 +25,7 @@ module HTML
             'video'      => ['src', 'controls']
           },
           :protocols => {
-            'a'          => {'href' => ['ftp', 'http', 'https', 'irc', 'mailto', 'xmpp', 'ed2k', 'magnet', :relative]},
+            'a'          => {'href' => ['ftp', 'http', 'https', 'irc', 'mailto', 'xmpp', 'ed2k', 'magnet', 'tel', :relative]},
             'blockquote' => {'cite' => ['http', 'https', :relative]},
             'img'        => {'src'  => ['http', 'https', :relative]},
             'q'          => {'cite' => ['http', 'https', :relative]}

--- a/lib/html/pipeline/linuxfr.rb
+++ b/lib/html/pipeline/linuxfr.rb
@@ -7,7 +7,30 @@ module HTML
         toc_minimal_length: 5000,
         toc_header: "<h2 class=\"sommaire\">Sommaire</h2>\n",
         svgtex_url: "http://localhost:16000",
-        host: "linuxfr.org"
+        host: "linuxfr.org",
+        whitelist: {
+          :elements => %w(a abbr b blockquote br cite code dd del dfn div dl dt em
+            h1 h2 h3 h4 h5 h6 hr i img ins kbd li mark meter ol p pre
+            q s samp small source span strong sub sup table tbody td
+            tfooter th thead tr time ul var video wbr),
+          :remove_contents => ['script'],
+          :attributes => {
+            :all         => ['data-after', 'data-id', 'id', 'title', 'class'],
+            'a'          => ['href', 'name'],
+            'blockquote' => ['cite'],
+            'img'        => ['alt', 'height', 'src', 'width'],
+            'q'          => ['cite'],
+            'source'     => ['src', 'type', 'media'],
+            'time'       => ['datetime'],
+            'video'      => ['src', 'controls']
+          },
+          :protocols => {
+            'a'          => {'href' => ['ftp', 'http', 'https', 'irc', 'mailto', 'xmpp', 'ed2k', 'magnet', :relative]},
+            'blockquote' => {'cite' => ['http', 'https', :relative]},
+            'img'        => {'src'  => ['http', 'https', :relative]},
+            'q'          => {'cite' => ['http', 'https', :relative]}
+          }
+        }
       }
 
       def self.render(text)

--- a/lib/html/pipeline/version.rb
+++ b/lib/html/pipeline/version.rb
@@ -1,5 +1,5 @@
 module HTML
   class Pipeline
-    VERSION = "0.15.5"
+    VERSION = "0.15.6"
   end
 end


### PR DESCRIPTION
Allow to use `tel:` URI as requested: https://linuxfr.org/suivi/lien-href-tel