### PR TITLE
Allow tel schema by extending constant

### DIFF
--- a/lib/html/pipeline/linuxfr.rb
+++ b/lib/html/pipeline/linuxfr.rb
@@ -1,4 +1,8 @@
 # encoding: utf-8
+
+require_relative "filter"
+require_relative "sanitization_filter"
+
 module HTML
   class Pipeline
 
@@ -7,7 +11,12 @@ module HTML
         toc_minimal_length: 5000,
         toc_header: "<h2 class=\"sommaire\">Sommaire</h2>\n",
         svgtex_url: "http://localhost:16000",
-        host: "linuxfr.org"
+        host: "linuxfr.org",
+        whitelist: HTML::Pipeline::SanitizationFilter::WHITELIST.merge(
+          :protocols => {
+            'a'          => {'href' => ['tel']}
+              }
+        ),
       }
 
       def self.render(text)

--- a/lib/html/pipeline/version.rb
+++ b/lib/html/pipeline/version.rb
@@ -1,5 +1,5 @@
 module HTML
   class Pipeline
-    VERSION = "0.15.5"
+    VERSION = "0.15.6"
   end
 end


### PR DESCRIPTION
Allow to use `tel:` URI as requested: https://linuxfr.org/suivi/lien-href-tel

Same idea than #3 but without copying default value.

To be able to use other class constant inside the CONTEXT constant, I had to add these two `require_relative` call.