### PR TITLE
Migration rails 7

### DIFF
--- a/html-pipeline-linuxfr.gemspec
+++ b/html-pipeline-linuxfr.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency "nokogiri",        "~> 1.6"
   gem.add_dependency "redcarpet",       "~> 3.4"
   gem.add_dependency "pygments.rb",     "~> 1.1"
-  gem.add_dependency "sanitize",        "~> 4.0"
+  gem.add_dependency "sanitize",        "~> 5.0"
   gem.add_dependency "escape_utils",    "~> 1.2"
-  gem.add_dependency "activesupport",   "~> 5.0"
+  gem.add_dependency "activesupport",   "~> 6.0"
   gem.add_dependency "patron",          "~> 0.8"
 
   gem.add_development_dependency "test-unit"

--- a/html-pipeline-linuxfr.gemspec
+++ b/html-pipeline-linuxfr.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pygments.rb",     "~> 1.1"
   gem.add_dependency "sanitize",        "~> 5.0"
   gem.add_dependency "escape_utils",    "~> 1.2"
-  gem.add_dependency "activesupport",   "~> 6.0"
+  gem.add_dependency "activesupport",   "~> 7.0"
   gem.add_dependency "patron",          "~> 0.8"
 
   gem.add_development_dependency "test-unit"

--- a/lib/html/pipeline/version.rb
+++ b/lib/html/pipeline/version.rb
@@ -1,5 +1,5 @@
 module HTML
   class Pipeline
-    VERSION = "0.16.0"
+    VERSION = "0.17.0"
   end
 end

--- a/lib/html/pipeline/version.rb
+++ b/lib/html/pipeline/version.rb
@@ -1,5 +1,5 @@
 module HTML
   class Pipeline
-    VERSION = "0.15.7"
+    VERSION = "0.16.0"
   end
 end


### PR DESCRIPTION
Afin de permettre l'évolution de linuxfr vers rails 6, puis 7, changement de dépendances.