### PR TITLE
upgrade sanitize to 6.0 to remove dependency on nokogumbo

### DIFF
--- a/html-pipeline-linuxfr.gemspec
+++ b/html-pipeline-linuxfr.gemspec
@@ -4,12 +4,13 @@ require File.expand_path("../lib/html/pipeline/version", __FILE__)
 Gem::Specification.new do |gem|
   gem.name          = "html-pipeline-linuxfr"
   gem.version       = HTML::Pipeline::VERSION
-  gem.license       = "MIT"
+  gem.licenses      = ["MIT"]
   gem.authors       = ["Ryan Tomayko", "Jerry Cheung", "Bruno Michel"]
   gem.email         = ["ryan@github.com", "jerry@github.com", "bmichel@menfin.info"]
   gem.description   = %q{LinuxFr.org HTML processing filters and utilities, adapted from those of GitHub}
   gem.summary       = %q{Helpers for processing content through a chain of filters}
   gem.homepage      = "https://github.com/nono/html-pipeline-linuxfr"
+  gem.metadata      = { "source_code_uri" => "https://github.com/nono/html-pipeline-linuxfr"}
 
   gem.files         = `git ls-files`.split $/
   gem.test_files    = gem.files.grep(%r{^test})
@@ -18,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "nokogiri",        "~> 1.6"
   gem.add_dependency "redcarpet",       "~> 3.4"
   gem.add_dependency "pygments.rb",     "~> 1.1"
-  gem.add_dependency "sanitize",        "~> 5.0"
+  gem.add_dependency "sanitize",        "~> 6.1"
   gem.add_dependency "escape_utils",    "~> 1.2"
   gem.add_dependency "activesupport",   "~> 7.0"
   gem.add_dependency "patron",          "~> 0.8"

--- a/lib/html/pipeline/version.rb
+++ b/lib/html/pipeline/version.rb
@@ -1,5 +1,5 @@
 module HTML
   class Pipeline
-    VERSION = "0.17.0"
+    VERSION = "0.17.1"
   end
 end


### PR DESCRIPTION
Sanitize a passé à une nouvelle version majeur car le projet n'est plus que compatible avec Ruby >= 2.5.

Cette mise à jour permet d'enlever l'avertissement à propos de nokogori et nokogumbo: https://github.com/linuxfrorg/linuxfr.org/pull/383